### PR TITLE
msg/async: fix rdma exchange port, parse string bug

### DIFF
--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -1105,7 +1105,7 @@ int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
     ldout(cct, 1) << __func__ << " got bad length (" << r << ") " << dendl;
     r = -EINVAL;
   } else { // valid message
-    sscanf(msg, "%hu:%x:%x:%x:%s", &(im.lid), &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
+    sscanf(msg, "%hx:%x:%x:%x:%s", &(im.lid), &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
     wire_gid_to_gid(gid, &(im.gid));
     ldout(cct, 5) << __func__ << " recevd: " << im.lid << ", " << im.qpn << ", " << im.psn << ", " << im.peer_qpn << ", " << gid  << dendl;
   }


### PR DESCRIPTION
msg/async: fix rdma exchange port, parse string bug

function send_msg encode struct IBSYNMsg to a string, and recv_msg parse the string.

In the function send_msg, im.lid (unsigned short int) is formatted into a string with format string %04x, 
so, recv_msg should read im.lid from the string with format string %hx instead of %hu (unsigned short).

Fixes: https://tracker.ceph.com/issues/38391
Signed-off-by: Peng Liu <liupeng37@baidu.com>
